### PR TITLE
Publish Dokka-generated Java and Kotlin docs to GH Pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,3 +139,35 @@ jobs:
           password: ${{ secrets.SONATYPE_API_KEY }}
           staging_repository_id: ${{ needs.create-staging-repository.outputs.repository_id }}
           base_url: ${{ env.SONATYPE_BASE_URL }}
+
+  publish-docs:
+    needs: [publish, finalize-staging-repository]
+    name: Publish API reference to GitHub Pages
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Cache gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Builds docs and publish to GitHub Pages
+        env:
+          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew gitPublishPush --stacktrace

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Be sure to substitute `{company-code}` and `{token}` for the correct values.
 
 If using the iOS or Android SDKs, you will provide the Streem Token to the client, and pass to the Streem SDK via `Streem.identify()` (iOS) or `Streem.login()` (Android).  More details can be found in the documentation of the individual SDKs.
 
+## API Reference
+
+* Kotlin API reference: <https://streem.github.io/streem-sdk-jvm/kotlin/>
+* Java API reference: <https://streem.github.io/streem-sdk-jvm/java/>
+
 ## License
 
 This repo is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
You can see a sample of the published docs at https://streem.github.io/streem-sdk-jvm/kotlin/ and https://streem.github.io/streem-sdk-jvm/java/.