### PR TITLE
Use a valid extension on the avatar URL in the example server

### DIFF
--- a/examples/tokenserver/src/main/kotlin/pro/streem/examples/tokenserver/Routing.kt
+++ b/examples/tokenserver/src/main/kotlin/pro/streem/examples/tokenserver/Routing.kt
@@ -22,7 +22,7 @@ fun Application.configureRouting() {
                 val token = streem.buildToken(req.id) {
                     name = req.name
                     email = req.email
-                    avatarUri = URI.create("https://robohash.org/$userId")
+                    avatarUri = URI.create("https://robohash.org/$userId.png")
                 }
 
                 call.respond(TokenResponse(token = token))


### PR DESCRIPTION
The Streem backend will refuse avatar URLs that don't have a valid image file extension.
